### PR TITLE
chore: add var.ssl_policy for alb https listener

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ from the profile icon `Reset password` menu in the upper right corner.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| consumer\_security\_group\_id | n/a | `string` | `null` | no |
+| create\_consumer\_security\_group | n/a | `bool` | `false` | no |
 | es\_availability\_zone\_count | Number of Availability Zones for the domain to use with zone\_awareness\_enabled. 1 means the zone\_awareness\_enabled is false | `number` | `1` | no |
 | es\_ebs\_volume\_size | n/a | `number` | `10` | no |
 | es\_encrypt\_at\_rest | n/a | `bool` | `false` | no |
@@ -66,11 +68,13 @@ from the profile icon `Reset password` menu in the upper right corner.
 | name\_suffix | If omitted, random string is used. | `string` | `""` | no |
 | private\_subnet\_cidr\_blocks | n/a | `list(string)` | `[]` | no |
 | private\_subnet\_ids | n/a | `list(string)` | `[]` | no |
-| public\_subnets | n/a | `list(string)` | `[]` | no |
-| public\_subnets\_cidr\_blocks | n/a | `list(string)` | `[]` | no |
+| public\_subnet\_cidr\_blocks | n/a | `list(string)` | `[]` | no |
+| public\_subnet\_ids | n/a | `list(string)` | `[]` | no |
 | route53\_zone\_id | Route53 zone id for kibana\_proxy\_host | `string` | n/a | yes |
 | service\_ingress\_cidr\_rules | n/a | `list(string)` | <pre>[<br>  "0.0.0.0/0"<br>]</pre> | no |
+| ssl\_policy | n/a | `string` | `"ELBSecurityPolicy-2016-08"` | no |
 | tags | n/a | `map(string)` | `{}` | no |
+| use\_vpc | n/a | `bool` | `true` | no |
 | vpc\_id | If you provide vpc\_id, elasticsearch will be deployed in that vpc. Or it is distributed outside the vpc. | `string` | n/a | yes |
 
 ## Outputs

--- a/main.tf
+++ b/main.tf
@@ -242,6 +242,7 @@ resource "aws_lb_listener" "https" {
   port              = "443"
   protocol          = "HTTPS"
   certificate_arn   = module.acm.this_acm_certificate_arn
+  ssl_policy        = var.ssl_policy
 
   default_action {
     target_group_arn = aws_lb_target_group.main.id

--- a/variables.tf
+++ b/variables.tf
@@ -111,6 +111,11 @@ variable "consumer_security_group_id" {
   default = null
 }
 
+variable "ssl_policy" {
+  type = string
+  default = "ELBSecurityPolicy-2016-08"
+}
+
 variable "tags" {
   type    = map(string)
   default = {}


### PR DESCRIPTION
resolve #3 
- add var.ssl_policy
- default is `ELBSecurityPolicy-2016-08`
- Available policies: https://docs.aws.amazon.com/elasticloadbalancing/latest/application/create-https-listener.html